### PR TITLE
fix: pass secrets to reusable CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,3 +8,4 @@ on:
 jobs:
   ci:
     uses: builtnorth/.github/.github/workflows/composer-package-ci.yml@main
+    secrets: inherit


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by inheriting secrets for the CI job. This will allow the workflow to access repository or organization secrets as needed.